### PR TITLE
Prefer using python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ and (ii) prefix to ASN metadata using CAIDA's prefix2AS datasets.
 ## Pre-requisites
 Before installing PyIPMeta, you will need:
   - [libipmeta (>= 3.1.0)](https://github.com/CAIDA/libipmeta)
-  - Python setuptools (`sudo apt install python-setuptools` on Ubuntu)
-  - Python development headers (`sudo apt install python-dev` on Ubuntu)
+  - Python setuptools (`sudo apt install python3-setuptools` on Ubuntu)
+  - Python development headers (`sudo apt install python3-dev` on Ubuntu)
 
 ## Install PyIPMeta
 
@@ -17,11 +17,11 @@ First, either clone this GitHub repo, or download the latest
 Then,
 
  ```
- $ python setup.py build_ext
- # python setup.py install
+ $ python3 setup.py build_ext
+ # python3 setup.py install
  ```
 
-_Note:_ use `python setup.py install --user` to install the library in
+_Note:_ use `python3 setup.py install --user` to install the library in
 your home directory.
 
 If you prefer to install in a virtual environment, and also want libipmeta
@@ -29,7 +29,7 @@ installed in that virtual environment, then:
 
 1. Activate the virtual environment
 2. When building libipmeta, add `--prefix=$VIRTUAL_ENV` to the `./configure` command
-3. When building pyipmeta, replace the `build_ext` command with `LD_RUN_PATH=$VIRTUAL_ENV python setup.py build_ext -I $VIRTUAL_ENV/include -L $VIRTUAL_ENV/lib`
+3. When building pyipmeta, replace the `build_ext` command with `LD_RUN_PATH=$VIRTUAL_ENV python3 setup.py build_ext -I $VIRTUAL_ENV/include -L $VIRTUAL_ENV/lib`
 
 ## Usage
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,9 @@ Maintainer: CAIDA Software Maintainer <software@caida.org>
 Section: python
 Priority: optional
 Build-Depends: dh-python, debhelper (>= 9), libipmeta2-dev (>= 3.1.0),
-  python-setuptools, python-all-dev, python-dateutil
+  python-setuptools, python3-setuptools,
+  python-all-dev, python3-all-dev,
+  python-dateutil, python3-dateutil
 Standards-Version: 3.9.6
 Homepage: https://github.com/CAIDA/pyipmeta
 
@@ -11,5 +13,12 @@ Package: python-pyipmeta
 Architecture: any
 Depends: ${misc:Depends}, ${python:Depends}, ${shlibs:Depends}
 Description: Python interface to libipmeta
+ Provides a high-level interface for live and historical BGP data
+ analysis.
+
+Package: python3-pyipmeta
+Architecture: any
+Depends: ${misc:Depends}, ${python3:Depends}, ${shlibs:Depends}
+Description: Python3 interface to libipmeta
  Provides a high-level interface for live and historical BGP data
  analysis.

--- a/debian/rules
+++ b/debian/rules
@@ -4,9 +4,11 @@
 # Tue, 13 Aug 2019 13:42:49 -0700
 export PYBUILD_NAME=pyipmeta
 export PYBUILD_DISABLE=test
+# don't install script for the python2 package, could clobber the python3 one
+export PYBUILD_AFTER_INSTALL_python2=rm -f {destdir}/usr/bin/pyipmeta-lookup
+
 %:
-# 	dh $@ --with python2,python3 --buildsystem=pybuild
-	dh $@ --with python2 --buildsystem=pybuild
+	dh $@ --with python2,python3 --buildsystem=pybuild
 
 override_dh_auto_install:
 	dh_auto_install

--- a/example/httpapi-simple.py
+++ b/example/httpapi-simple.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This file is part of pyipmeta.
 #

--- a/example/httpapi.py
+++ b/example/httpapi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This file is part of pyipmeta.
 #

--- a/example/ipmeta.service
+++ b/example/ipmeta.service
@@ -3,7 +3,7 @@ Description=ipmeta server
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python /opt/ipmeta/ipmeta-service.py -l 0.0.0.0 -P 80
+ExecStart=/usr/bin/python3 /opt/ipmeta/ipmeta-service.py -l 0.0.0.0 -P 80
 WorkingDirectory=/opt/ipmeta/
 Restart=always
 RestartSec=2

--- a/example/lpf-kafka.py
+++ b/example/lpf-kafka.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This file is part of pyipmeta.
 #

--- a/pyipmeta/pyipmeta.py
+++ b/pyipmeta/pyipmeta.py
@@ -74,7 +74,8 @@ class IpMeta:
         if self.target_time is None and self.reload_period is not None:
             self.reloader_stop = threading.Event()
             reloader_thread = threading.Thread(target=IpMeta._periodic_reload,
-                    args=(weakref.ref(self),), daemon=True)
+                    args=(weakref.ref(self),))
+            reloader_thread.daemon = True
             reloader_thread.start()
 
     def __del__(self):

--- a/test/_pyipmeta_test.py
+++ b/test/_pyipmeta_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This file is part of pyipmeta.
 #

--- a/test/pyipmeta_test.py
+++ b/test/pyipmeta_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This file is part of pyipmeta.
 #


### PR DESCRIPTION
It looks like PR CAIDA/pyipmeta#11 added python3 support.

This pull request updates all the documentation, examples and tests to use python3 by default, as well as adding configuration to build Debian packages for both python3 and python3.

This hopefully means CAIDA/pyipmeta#20 can be solved by building new Debian packages and adding them to pkg.caida.org.