### PR TITLE
No longer build python2 packages.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,18 +3,9 @@ Maintainer: CAIDA Software Maintainer <software@caida.org>
 Section: python
 Priority: optional
 Build-Depends: dh-python, debhelper (>= 9), libipmeta2-dev (>= 3.1.0),
-  python-setuptools, python3-setuptools,
-  python-all-dev, python3-all-dev,
-  python-dateutil, python3-dateutil
+  python3-setuptools, python3-all-dev, python3-dateutil
 Standards-Version: 3.9.6
 Homepage: https://github.com/CAIDA/pyipmeta
-
-Package: python-pyipmeta
-Architecture: any
-Depends: ${misc:Depends}, ${python:Depends}, ${shlibs:Depends}
-Description: Python interface to libipmeta
- Provides a high-level interface for live and historical BGP data
- analysis.
 
 Package: python3-pyipmeta
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -4,11 +4,9 @@
 # Tue, 13 Aug 2019 13:42:49 -0700
 export PYBUILD_NAME=pyipmeta
 export PYBUILD_DISABLE=test
-# don't install script for the python2 package, could clobber the python3 one
-export PYBUILD_AFTER_INSTALL_python2=rm -f {destdir}/usr/bin/pyipmeta-lookup
 
 %:
-	dh $@ --with python2,python3 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_auto_install:
 	dh_auto_install


### PR DESCRIPTION
Modern Debian/Ubuntu releases no longer have python2 support.